### PR TITLE
require('FileReader') should be require('filereader')

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -13,7 +13,7 @@
   var EventEmitter = require('events').EventEmitter
     , forEachAsync = require('foreachasync').forEachAsync
     , File = require('File')
-    , FileReader = require('FileReader')
+    , FileReader = require('filereader')
     ;
 
   function isFile(o) {


### PR DESCRIPTION
`FileReader` is actually known as `filereader` in its package.json. Trying to import it as `FileReader` causes the node program to crash on a case-sensitive filesystem.
